### PR TITLE
Fix rendering differences with node-sass 3.3 and 3.4

### DIFF
--- a/csstyle.scss
+++ b/csstyle.scss
@@ -15,22 +15,22 @@ $csstyle-root-id: 'csstyle' !default;
 // build selectors
 @function _build_selector($prefix, $names){
     $selector: "";
-    
+
     @for $i from 1 through length($names){
       $selector: $selector + $prefix + nth($names, $i);
-      
+
       @if($i != length($names)){
         $selector: $selector + ",";
       }
     }
-    
+
     @return $selector;
 }
 
 // components
 @mixin component($names...){
   #{_build_selector("." + $csstyle-component-symbol, $names)}{
-    @content
+    @content;
   }
 }
 
@@ -48,6 +48,9 @@ $csstyle-root-id: 'csstyle' !default;
 @mixin part($names...){
     // check if nested in an option
     $optionIndex: str-index(#{&}, "." + $csstyle-option-symbol);
+    @if str-index($csstyle-option-symbol, "\\") == 1 and $optionIndex == null {
+      $optionIndex: str-index(#{&}, "." + str-slice($csstyle-option-symbol, 2));
+    }
     $optionIndex: 0 !default;
     $optionIndex: $optionIndex - 1;
 
@@ -57,7 +60,7 @@ $csstyle-root-id: 'csstyle' !default;
     $partIndex: $partIndex - 1;
 
     $component: str-slice(#{&}, 0, $optionIndex);
-    
+
     // part is nested in an option
     @if $optionIndex > 0 {
       // part is also nested in another part


### PR DESCRIPTION
https://github.com/geddski/csstyle/issues/58

Escaped option symbol renders differently between ruby Sass and
node-sass. When the `$optionIndex` variable is `null` in the `part`
mixin, in the case of node-sass, use the `str-slice` function to
modify the `str-index` value assigned to `$optionIndex`.