### PR TITLE
Additional nesting issue fixes

### DIFF
--- a/csstyle.scss
+++ b/csstyle.scss
@@ -60,19 +60,12 @@ $csstyle-root-id: 'csstyle' !default;
     $partIndex: $partIndex - 1;
 
     $component: str-slice(#{&}, 0, $optionIndex);
+    $component: str-slice($component, 0, $partIndex);
 
-    // part is nested in an option
-    @if $optionIndex > 0 {
-      // part is also nested in another part
-      @if ($partIndex > 0){
-        #{_build_selector("&" + $csstyle-part-symbol, $names)}{
-          @content;
-        }
-      }
-      @else{
-        #{_build_selector("& " + $component + $csstyle-part-symbol, $names)}{
-          @content;
-        }
+    // part is nested in an option or in another part
+    @if $optionIndex > 0 or $partIndex > 0 {
+      #{_build_selector("& " + $component + $csstyle-part-symbol, $names)}{
+        @content;
       }
     }
     @else {


### PR DESCRIPTION
I was having additional issues to the ones described in issue #58 for the following:

```html
<div class="Component">
    <div class="Component__ParentPart --ShowChild">
        <div class="Component__ChildPart">Show me when my parent has --ShowChild option</div>
    </div>  
</div>
```

```scss
@include component(Component) {
  @include part(ChildPart) {
    display: none;
  }
  @include part(ParentPart) {
    @include option(ShowChild) {
      @include part(ChildPart) {
        display: block;
      }
    }
  }
}
```

Before the committed changes, the above compiled to:

```css
.Component__ChildPart {
  display: none; }

.Component__ParentPart.\--ShowChild__ChildPart {
  display: block; }
```

Now, after these committed changes, it compiles to:

```css
.Component__ChildPart {
  display: none; }

.Component__ParentPart.\--ShowChild .Component__ChildPart {
  display: block; }
```